### PR TITLE
Add Mac support, make media directory selectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,15 @@ Components include:
   * [Watchtower automatic container updater](https://github.com/v2tec/watchtower)
   * [NetData System Monitoring](https://github.com/firehol/netdata)
   * [Duplicati Backup Software](https://www.duplicati.com/)
-  
+
 # Prerequisites
+
+## MacOS
+
+  * MacOS High Sierra
+  * [Docker for Mac](https://docs.docker.com/docker-for-mac/install/)
+
+## Linux
 
   * [Ubuntu 16.04 LTS](https://www.ubuntu.com/)
   * [VPN account from Private internet Access](https://www.privateinternetaccess.com/pages/buy-vpn/Stevie) (Please see [binhex's Github Repo](https://github.com/binhex/arch-delugevpn) if you want to use a different VPN)
@@ -23,12 +30,12 @@ Components include:
   * [Docker](https://www.docker.com/)
   * [Python 2.7](https://www.python.org/)
   * [Docker-Compose](https://docs.docker.com/compose/)
-  
+
 **PLEASE NOTE**
 
 For simplicity's sake (eg. automatic dependency management), the method used to install these packages is Ubuntu 16.04's default package manager, [APT](https://wiki.debian.org/Apt).  There are several other methods that work just as well, if not better (especially if you don't have superuser access on your system), so use whichever method you prefer.  Continue when you've successfully installed all packages listed.
 
-### Installation:
+#### Installation:
 
 (You'll need superuser access to run these commands successfully)
 
@@ -85,20 +92,20 @@ As the script runs you will be prompted for:
     * **latest**
     * **public**
     * **plexpass**
-    
+
 Note: If you choose plexpass as your version you may optionally specify CLAIM_TOKEN - you can get your claim token by logging in at [plex.tv/claim](https://www.plex.tv/claim)
 
 3. The "style" of Portainer to use
     *  **auth** (will require a password, require a persistent volume map, and will need you to select the endpoint to manage)
     *  **noauth** (will not require a password for access and will automatically connect to the local Docker sock endpoint)
-    
+
 4. Credentials for the Deluge daemon (this is needed for the CouchPotato container)
     * **username**
     * **password**
 
 Upon completion, the script will launch your mediabox containers.
 
-##### **mediabox** has been tested to work on Ubuntu 16.04 LTS - Server and Desktop
+##### **mediabox** has been tested to work on Ubuntu 16.04 LTS - Server and Desktop and MacOS High Sierra
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,9 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './couchpotato:/config'
-            - './content/completed:/downloads'
-            - './content/movies:/movies'
+            - '${DATADIRECTORY}/couchpotato:/config'
+            - '${MEDIADIRECTORY}/completed:/downloads'
+            - '${MEDIADIRECTORY}/movies:/movies'
             - '/etc/localtime:/etc/localtime:ro'
 
     # ----------------------------------------
@@ -70,8 +70,8 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './content:/data'
-            - './delugevpn/config:/config'
+            - '${MEDIADIRECTORY}:/data'
+            - '${DATADIRECTORY}/delugevpn/config:/config'
             - '/etc/localtime:/etc/localtime:ro'
 
     # ----------------------------------------
@@ -88,9 +88,9 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './duplicati:/config'
-            - './duplicati/backups:/backups'
-            - '${PWD}:/source'
+            - '${DATADIRECTORY}/duplicati:/config'
+            - '${DATADIRECTORY}/duplicati/backups:/backups'
+            - '${DATADIRECTORY}:/source'
             - '/etc/localtime:/etc/localtime:ro'
 
     # ----------------------------------------
@@ -107,7 +107,7 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './www:/www'
+            - '${DATADIRECTORY}/www:/www'
 
     # ----------------------------------------
     # MINIO
@@ -123,7 +123,7 @@ services:
             - MINIO_ACCESS_KEY=minio
             - MINIO_SECRET_KEY=minio123
         volumes:
-            - '${PWD}:/export'
+            - '${MEDIADIRECTORY}:/export'
         command: server /export
 
     # ----------------------------------------
@@ -157,7 +157,7 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './ombi:/config'
+            - '${DATADIRECTORY}/ombi:/config'
 
     # ----------------------------------------
     # PLEX
@@ -166,7 +166,7 @@ services:
         container_name: plex
         image: plexinc/pms-docker:${PMSTAG}
         restart: unless-stopped
-        network_mode: "host"
+        network_mode: "bridge"
         ports:
             - '${IP_ADDRESS}:32400:32400/tcp'
             - '${IP_ADDRESS}:3005:3005/tcp'
@@ -181,14 +181,14 @@ services:
             - PLEX_CLAIM=${PMSTOKEN}
             - ADVERTISE_IP=http://${IP_ADDRESS}:32400/
             - ALLOWED_NETWORKS=${CIDR_ADDRESS}
-            - PLEX_UID=${PUID} 
+            - PLEX_UID=${PUID}
             - PLEX_GID=${PGID}
         hostname: ${HOSTNAME}
         volumes:
-            - './plex:/config'
-            - './plex/transcode:/transcode'
-            - './content/tv:/data/tvshows'
-            - './content/movies:/data/movies'
+            - '${DATADIRECTORY}/plex:/config'
+            - '${DATADIRECTORY}/plex/transcode:/transcode'
+            - '${MEDIADIRECTORY}/tv:/data/tvshows'
+            - '${MEDIADIRECTORY}/movies:/data/movies'
             - '/etc/localtime:/etc/localtime:ro'
 
     # ----------------------------------------
@@ -205,8 +205,8 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './plexpy:/config'
-            - './plex/Library/Application Support/Plex Media Server/Logs:/logs:ro'
+            - '${DATADIRECTORY}/plexpy:/config'
+            - '${DATADIRECTORY}/plex/Library/Application Support/Plex Media Server/Logs:/logs:ro'
             - '/etc/localtime:/etc/localtime:ro'
         depends_on:
             - plex
@@ -222,7 +222,7 @@ services:
         ports:
             - '${IP_ADDRESS}:9000:9000'
         volumes:
-            - './portainer:/data'
+            - '${DATADIRECTORY}/portainer:/data'
             - '/var/run/docker.sock:/var/run/docker.sock'
             - '/etc/localtime:/etc/localtime:ro'
         command: ${PORTAINERSTYLE} -H unix:///var/run/docker.sock
@@ -241,9 +241,9 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './radarr:/config'
-            - './content/completed:/downloads'
-            - './content/movies:/movies'
+            - '${DATADIRECTORY}/radarr:/config'
+            - '${MEDIADIRECTORY}/completed:/downloads'
+            - '${MEDIADIRECTORY}/movies:/movies'
             - '/etc/localtime:/etc/localtime:ro'
     
     # ----------------------------------------
@@ -260,9 +260,9 @@ services:
             - PUID=${PUID}
             - PGID=${PGID}
         volumes:
-            - './sickrage:/config'
-            - './content/completed:/downloads'
-            - './content/tv:/tv'
+            - '${DATADIRECTORY}/sickrage:/config'
+            - '${MEDIADIRECTORY}/completed:/downloads'
+            - '${MEDIADIRECTORY}/tv:/tv'
             - '/etc/localtime:/etc/localtime:ro'
 
     # ----------------------------------------

--- a/mediabox.sh
+++ b/mediabox.sh
@@ -8,13 +8,17 @@ PUID=`id -u $localuname`
 PGID=`id -g $localuname`
 # Get Hostname
 thishost=`hostname`
-# Get IP Address
-locip=`hostname -I | awk '{print $1}'`
-# Get Time Zone
-time_zone=`cat /etc/timezone`
+# Get IP Address and Time Zone
+if [ `uname` == 'Darwin' ]; then
+    locip=`(ifconfig en0 || ifconfig en1) | grep 'inet ' | awk '{print $2}'`
+    time_zone=`ls -l /etc/localtime | sed -E 's/.*zoneinfo\/(.*)$/\1/'`
+else
+    locip=`hostname -I | awk '{print $1}'`
+    time_zone=`cat /etc/timezone`
+fi
 
 # CIDR - this assumes a 255.255.255.0 netmask - If your config is different use the custom CIDR line
-lannet=`hostname -I | awk '{print $1}' | sed 's/\.[0-9]*$/.0\/24/'`
+lannet=`echo $locip | sed 's/\.[0-9]*$/.0\/24/'`
 # Custom CIDR (comment out the line above if using this)
 # Uncomment the line below and enter your CIDR info so the line looks like: lannet=xxx.xxx.xxx.0/24
 #lannet=
@@ -26,10 +30,10 @@ printf "\n\n"
 
 # Get info needed for PLEX Official image
 read -p "Which PLEX release do you want to run? By default 'public' will be used. (latest, public, plexpass): " pmstag
-read -p "If you have PLEXPASS what is your Claim Token: (Optional) " pmstoken
+read -p "If you have PLEXPASS what is your Claim Token from https://www.plex.tv/claim/ (Optional): " pmstoken
 # If not set - set PMS Tag to Public:
-if [ -z "$pmstag" ]; then 
-   pmstag=public 
+if [ -z "$pmstag" ]; then
+   pmstag=public
 fi
 
 # Get the info for the style of Portainer to use
@@ -39,30 +43,46 @@ if [ -z "$portainerstyle" ]; then
 elif [ $portainerstyle == "noauth" ]; then
    portainerstyle=--no-auth
 elif [ $portainerstyle == "auth" ]; then
-   portainerstyle= 
-fi   
+   portainerstyle=
+fi
+
+# Get the desired directory for media storage
+read -p "Where do you want to store media? By default './content' will be used: " mediadirectory
+if [ -z "$mediadirectory" ]; then
+   mediadirectory='./content'
+fi
+# If the user entered '~' in the path, replace it with '$HOME' so it gets properly expanded
+mediadirectory="${mediadirectory/#\~/$HOME}"
+
+# Get the desired directory for media storage
+read -p "Where do you want to store configuation data? By default '.' (this directory) will be used: " datadirectory
+if [ -z "$datadirectory" ]; then
+   datadirectory='.'
+fi
+# If the user entered '~' in the path, replace it with '$HOME' so it gets properly expanded
+datadirectory="${datadirectory/#\~/$HOME}"
 
 # Create the directory structure
-`mkdir -p content/completed`
-`mkdir -p content/incomplete`
-`mkdir -p content/movies`
-`mkdir -p content/tv`
-`mkdir -p couchpotato`
-`mkdir -p delugevpn`
-`mkdir -p delugevpn/config/openvpn`
-`mkdir -p duplicati`
-`mkdir -p duplicati/backups`
-`mkdir -p ombi`
-`mkdir -p "plex/Library/Application Support/Plex Media Server/Logs"`
-`mkdir -p plexpy`
-`mkdir -p portainer`
-`mkdir -p radarr`
-`mkdir -p sickrage`
-`mkdir -p www`
+mkdir -p "$mediadirectory"/completed
+mkdir -p "$mediadirectory"/incomplete
+mkdir -p "$mediadirectory"/movies
+mkdir -p "$mediadirectory"/tv
+mkdir -p "$datadirectory"/couchpotato
+mkdir -p "$datadirectory"/delugevpn
+mkdir -p "$datadirectory"/delugevpn/config/openvpn
+mkdir -p "$datadirectory"/duplicati
+mkdir -p "$datadirectory"/duplicati/backups
+mkdir -p "$datadirectory"/ombi
+mkdir -p "$datadirectory/plex/Library/Application Support/Plex Media Server/Logs"
+mkdir -p "$datadirectory"/plexpy
+mkdir -p "$datadirectory"/portainer
+mkdir -p "$datadirectory"/radarr
+mkdir -p "$datadirectory"/sickrage
+mkdir -p "$datadirectory"/www
 # Move the PIA VPN files
-`mv ca.ovpn delugevpn/config/openvpn/ca.ovpn`
-`mv ca.rsa.2048.crt delugevpn/config/openvpn/ca.rsa.2048.crt`
-`mv crl.rsa.2048.pem delugevpn/config/openvpn/crl.rsa.2048.pem`
+cp ca.ovpn "$datadirectory"/delugevpn/config/openvpn/ca.ovpn
+cp ca.rsa.2048.crt "$datadirectory"/delugevpn/config/openvpn/ca.rsa.2048.crt
+cp crl.rsa.2048.pem "$datadirectory"/delugevpn/config/openvpn/crl.rsa.2048.pem
 
 ###################
 # TROUBLESHOOTING #
@@ -74,19 +94,20 @@ fi
 # printf "### Collected Variables are echoed below. ###\n"
 # printf "\n"
 # printf "The username is: $localuname\n"
+# printf "The IP address is: $locip\n"
 # printf "The PUID is: $PUID\n"
 # printf "The PGID is: $PGID\n"
-# printf "The current directory is: $PWD\n"
-# printf "The IP address is: $locip\n"
 # printf "The CIDR address is: $lannet\n"
 # printf "The PIA Username is: $piauname\n"
 # printf "The PIA Password is: $piapass\n"
 # printf "The Hostname is: $thishost\n"
-# printf "The Timezone is: $timezone\n"
+# printf "The Timezone is: $time_zone\n"
 # printf "The Plex version is: $pmstag\n"
 # printf "The Plexpass Claim token is: $pmstoken\n"
 # printf "The Portainer style is: $portainerstyle\n"
 # printf "Note: A Portainer style of 'blank' = the 'Normal Auth' style\n"
+# printf "The Media Directory is: $mediadirectory\n"
+# printf "The Data/Config Directory is: $datadirectory\n"
 
 # Create the .env file
 echo "Creating the .env file with the values we have gathered"
@@ -96,14 +117,15 @@ echo "HOSTNAME=$thishost" >> .env
 echo "IP_ADDRESS=$locip" >> .env
 echo "PUID=$PUID" >> .env
 echo "PGID=$PGID" >> .env
-echo "PWD=$PWD" >> .env
+echo "CIDR_ADDRESS=$lannet" >> .env
 echo "PIAUNAME=$piauname" >> .env
 echo "PIAPASS=$piapass" >> .env
-echo "CIDR_ADDRESS=$lannet" >> .env
 echo "TZ=$time_zone" >> .env
 echo "PMSTAG=$pmstag" >> .env
 echo "PMSTOKEN=$pmstoken" >> .env
 echo "PORTAINERSTYLE=$portainerstyle" >> .env
+echo "MEDIADIRECTORY=$mediadirectory" >> .env
+echo "DATADIRECTORY=$datadirectory" >> .env
 echo ".env file creation complete"
 printf "\n\n"
 
@@ -112,7 +134,7 @@ echo "The containers will now be pulled and launched"
 echo "This may take a while depending on your download speed"
 read -p "Press any key to continue... " -n1 -s
 printf "\n\n"
-`docker-compose up -d`
+docker-compose up -d
 printf "\n\n"
 
 # Let's configure the access to the Deluge Daemon for CouchPotato
@@ -125,30 +147,30 @@ printf "\n\n"
 printf "Configuring Deluge daemon access - UHTTPD index file - Permissions \n\n"
 
 # Configure DelugeVPN: Set Daemon access on, delete the core.conf~ file
-`while [ ! -f delugevpn/config/core.conf ]; do sleep 1; done`
-`docker stop delugevpn > /dev/null 2>&1`
-`rm delugevpn/config/core.conf~ > /dev/null 2>&1`
-`sed -i 's/"allow_remote": false,/"allow_remote": true,/g'  delugevpn/config/core.conf`
-`sed -i 's/"move_completed": false,/"move_completed": true,/g'  delugevpn/config/core.conf`
-`docker start delugevpn > /dev/null 2>&1`
+while [ ! -f "$datadirectory"/delugevpn/config/core.conf ]; do sleep 1; done
+docker stop delugevpn > /dev/null 2>&1
+rm -f "$datadirectory"/delugevpn/config/core.conf~ > /dev/null 2>&1
+perl -i -pe 's/"allow_remote": false,/"allow_remote": true,/g'  "$datadirectory"/delugevpn/config/core.conf
+perl -i -pe 's/"move_completed": false,/"move_completed": true,/g'  "$datadirectory"/delugevpn/config/core.conf
+docker start delugevpn > /dev/null 2>&1
 
 # Push the Deluge Daemon Access info the to Auth file
-`echo $daemonun:$daemonpass:10 >> ./delugevpn/config/auth`
+echo $daemonun:$daemonpass:10 >> "$datadirectory"/delugevpn/config/auth
 
 # Configure UHTTPD settings and Index file
-`docker stop uhttpd > /dev/null 2>&1`
-`mv index.html www/index.html` 
-`sed -i "s/locip/$locip/g" www/index.html`
-`sed -i "s/daemonun/$daemonun/g" www/index.html`
-`sed -i "s/daemonpass/$daemonpass/g" www/index.html`
-`cp .env www/env.txt`
-`docker start uhttpd > /dev/null 2>&1`
+docker stop uhttpd > /dev/null 2>&1
+cp index.html "$datadirectory"/www/index.html
+perl -i -pe "s/locip/$locip/g" "$datadirectory"/www/index.html
+perl -i -pe "s/daemonun/$daemonun/g" "$datadirectory"/www/index.html
+perl -i -pe "s/daemonpass/$daemonpass/g" "$datadirectory"/www/index.html
+cp .env "$datadirectory"/www/env.txt
+docker start uhttpd > /dev/null 2>&1
 
 # Fix the Healthcheck in Minio
 docker exec minio sed -i "s/404/403/g" /usr/bin/healthcheck.sh
 
-# Adjust the permissions on the content folder
-`chmod -R 0777 content/`
+# Adjust the permissions on the media folder
+chmod -R 0777 "$mediadirectory"
 
 printf "Setup Complete - Open a browser and go to: \n\n"
 printf "http://$locip OR http://$thishost \n"


### PR DESCRIPTION
Thanks for the great set of configs! This was a joy to use :) I've made a couple changes that helped my situation (and might help others). I _think_ the changes I made are fully backwards-compatible, so you should see no change in behavior after merging this PR

Two changes required for mac support:
1. different method to get IP address and time zone
2. `sed -i` has different semantics -- instead use `perl -i -pe`

Other major changes:
1. Make the "Media" and "Data/Config" directories selectable

Some other minor changes:
1. Remove backticks from commands. AFAIK you only need them in order to capture the stdout, which doesn't seem needed in most of these places