### PR TITLE
allow hardware acceleration by mapping the DRI device

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,6 +294,8 @@ services:
             - PLEX_UID=${PUID}
             - PLEX_GID=${PGID}
         hostname: ${HOSTNAME}
+        devices:
+            - '/dev/dri:/dev/dri'
         volumes:
             - './plex:/config'
             - './plex/transcode:/transcode'


### PR DESCRIPTION
Hi,

Depending on the hardware in the machine, skylake, kaby lake etc there is support for hardware x26x encoding. By mapping the device it allows the plex docker container to use it.

HW acceleration still needs to be enabled from within plex:
![image](https://user-images.githubusercontent.com/999774/57574009-7a902f80-7431-11e9-9059-63e092f58b32.png)

And can then be verified in the dashboard that HW decoding is actually being used:
![image](https://user-images.githubusercontent.com/999774/57573995-62201500-7431-11e9-951b-4793fed6849e.png)
