### PR TITLE
Add Bazarr container

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Mediabox is an all Docker Container based media aggregator stack.
 
 Components include:
 
+* [Bazarr subtitle manager](https://www.bazarr.media/)
 * [Couchpotato movie library manager](https://couchpota.to/)
 * [Deluge torrent client (using VPN)](http://deluge-torrent.org/)
 * [Dozzle realtime log viewer](https://github.com/amir20/dozzle)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,27 @@ version: '3.5'
 services:
 
   # ----------------------------------------
+  # BAZARR
+  # ----------------------------------------
+  bazarr:
+    image: lscr.io/linuxserver/bazarr
+    container_name: bazarr
+    restart: unless-stopped
+    network_mode: "bridge"
+    ports:
+        - '${IP_ADDRESS}:6767:6767'
+    environment:
+        - PUID=${PUID}
+        - PGID=${PGID}
+        - TZ=${TZ}
+    volumes:
+        - './bazarr:/config'
+        - '${MOVIEDIR}:/movies'
+        - '${TVDIR}:/tv'
+        - '${MISCDIR}:/misc'
+        - '/etc/localtime:/etc/localtime:ro'
+
+  # ----------------------------------------
   # COUCHPOTATO
   # ----------------------------------------
   couchpotato:


### PR DESCRIPTION
Hi, 

I hope adding suggestions via PR is ok. [Bazarr](https://www.bazarr.media/) is a service used to find subtitles files in your library that are missing them in the format/language you desire. It is something I use on my modified mediabox install, and I thought others might find it useful as well.